### PR TITLE
feat: add hash to TorrentStatus

### DIFF
--- a/torrent_status.go
+++ b/torrent_status.go
@@ -16,6 +16,7 @@ package deluge
 
 import (
 	"context"
+
 	"github.com/gdm85/go-rencode"
 )
 
@@ -40,6 +41,7 @@ type TorrentStatus struct {
 	DownloadLocation    string `rencode:"v2only"`
 	DownloadPayloadRate int64
 	Name                string
+	Hash                string
 	NextAnnounce        int64
 	NumPeers            int64
 	NumPieces           int64
@@ -88,6 +90,7 @@ var (
 		"tracker_status",
 		"next_announce",
 		"name",
+		"hash",
 		"total_size",
 		"progress",
 		"num_seeds",


### PR DESCRIPTION
Add hash to TorrentStatus.  I need it for [a utility I am working on](https://github.com/kenstir/torinfo) that talks to Deluge and qbit.